### PR TITLE
Adding java 1.8.0 to be able to run KiuwanLocalAnalyzer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,5 @@ RUN sudo dnf install -y \
   python3-pygithub \
   ftp \
   glibc-devel.i686 \
+  java-1.8.0-openjdk-devel.x86_64 \
   && sudo dnf clean all


### PR DESCRIPTION
The KiuwanLocalAnalyzer is a static analysis tool that is mandatory to check all the code.